### PR TITLE
adapt code to missing value in yaml

### DIFF
--- a/create_jsonld.py
+++ b/create_jsonld.py
@@ -206,28 +206,27 @@ def yaml_to_jsonld(yaml_file_path):
         "name": data.get("model_name"),
         "alternateName": data.get("model_abbr"),
         "description": data.get("methods_long") or data.get("methods"),
-        "version": data.get("model_version"),
-        "license": data.get("license"),
-
-
-        # Add RSV disease information
-
+        "version": data.get("model_version")
+             # Add RSV disease information
     }
 
-    # Add the organization (team)
-    if data.get("team_name"):
-        jsonld["producer"] = {
-            "@type": "Organization",
-            "name": data.get("team_name"),
-            "alternateName": data.get("team_abbr"),
-            "url": data.get("website_url")
-        }
+    if data.get("license") not in ["NA", "na", "TBD"]:
+        jsonld["license"] = data.get("license")
 
-        if data.get("team_funding"):
-            jsonld["producer"]["funder"] = {
-                "@type": "Organization",
-                "description": data.get("team_funding")
-            }
+    if data.get("website_url") not in ["NA", "na", "TBD"]:
+        jsonld["website"] = data.get("website_url")
+
+     # Add the organization (team)
+    jsonld["producer"] = {
+        "@type": "Organization",
+        "name": data.get("team_name")
+    }
+
+    if data.get("team_funding") and data.get("team_funding") not in ["NA", "na", "TBD"]:
+        jsonld["producer"]["funder"] = {
+            "@type": "Organization",
+            "description": data.get("team_funding")
+        }
 
     # Add contributors as authors
     if "model_contributors" in data and data["model_contributors"]:


### PR DESCRIPTION
- adapt code to missing value in yaml
- minor fixes:
   - move website output "producer" section. The "producer" section seems to be focused on the organization and the website url can link to the model code, team information, etc.
   - remove alternate Name for team name. The alternate name was using the "team_abbr" and it's not really an alternate name, more an abbreviation for file name. 

Fixes #6 

